### PR TITLE
omit spinup check if data is not loaded from store

### DIFF
--- a/geb/model.py
+++ b/geb/model.py
@@ -418,7 +418,7 @@ class GEBModel(Module, HazardDriver, ABM_Model):
         # in run mode, verify that the spinup time range matches the stored time range
         if in_spinup:
             self._store_spinup_time_range()
-        else:
+        elif load_data_from_store:
             self._verify_spinup_time_range()
 
         if self.simulate_hydrology:


### PR DESCRIPTION
Quick fix to omit _verify_spinup_time_range() if data is not loaded from store. Will fail otherwise.
For some functions (e.g., estimate_return_periods) agent data is not required. Not loading this data reduces RAM load, but load_data_from_store=False failed in _verify_spinup_time_range().

closes issue #376 

# Pull Request Checklist

## Documentation
- [ ] All new or substantially edited functions have documentation in the style of documentation in other functions.
- [ ] Where neccesary, code comments are added focussing on *why* something is done, rather than *what* is done. The *what* should ideally be evident from the variable naming and structure.
- [ ] All added or substantially edited functions have type annotations for arguments and return types.

## Clarity
- [ ] All variable names are clear and understandable by a non-domain expert.
- [ ] Units are included unless super widely used default and in SI units (for example all hydrology units are standard in m).
- [ ] All monetary units are nominal USD (face value) for the respective years.

## Testing
- [ ] Tests that are not available on GitHub actions pass (primarly test_model.py).
- [ ] When there is an error, the code fails (early). I.e., the code doesn't silently fail.

*Thank you for helping maintain the code quality!*