### PR TITLE
Fix GPU detection logic for on SLURM cluster (detect if GPU physically present but not assigned)

### DIFF
--- a/geb/hazards/floods/workflows/utils.py
+++ b/geb/hazards/floods/workflows/utils.py
@@ -363,7 +363,25 @@ def run_sfincs_simulation(
             result: subprocess.CompletedProcess[bytes] = subprocess.run(
                 args=["nvidia-smi"], capture_output=True
             )
-            gpu: bool = result.returncode == 0
+            maybe_gpu: bool = result.returncode == 0
+
+            # if no GPU is found, there is no need to check further, set gpu to False
+            if not maybe_gpu:
+                gpu: bool = False
+            else:
+                # otherwise, check if we are in a SLURM job. We may be on a cluster
+                # where a GPU is physically present, but not allocated to the job
+                # and therefore not available for use.
+                in_SLURM_job: bool = "SLURM_JOB_ID" in os.environ
+                if in_SLURM_job:
+                    # in a SLURM job, if the job has access to the GPU
+                    gpu_ids: str | None = os.getenv(key="CUDA_VISIBLE_DEVICES")
+                    if gpu_ids is not None and len(gpu_ids) > 0:
+                        gpu: bool = True
+                    else:
+                        gpu: bool = False
+                else:
+                    gpu: bool = True
         else:
             gpu: bool = False
 


### PR DESCRIPTION
On a slurm cluster, it is possible that a gpu is physically present but not assigned to the job and thus not available. This PR tries to detect this scenario and if so, set GPU to not available in auto-mode

# Pull Request Checklist

## Documentation
- [ ] All new or substantially edited functions have documentation in the style of documentation in other functions.
- [ ] Where neccesary, code comments are added focussing on *why* something is done, rather than *what* is done. The *what* should ideally be evident from the variable naming and structure.
- [ ] All added or substantially edited functions have type annotations for arguments and return types.

## Clarity
- [ ] All variable names are clear and understandable by a non-domain expert.
- [ ] Units should be included and preferably as SI units.
- [ ] All monetary units are nominal USD (face value) for the respective years.

## Testing
- [ ] Tests that are not available on GitHub actions pass (primarly test_model.py).
- [ ] When there is an error, the code fails (early). I.e., the code doesn't silently fail.

*Thank you for helping maintain the code quality!*