### PR TITLE
Tim init multiple

### DIFF
--- a/geb/build/__init__.py
+++ b/geb/build/__init__.py
@@ -22,6 +22,7 @@ import pandas as pd
 import pyflwdir
 import rasterio
 import xarray as xr
+import yaml
 import zarr
 from affine import Affine
 from hydromt.data_catalog import DataCatalog
@@ -1082,18 +1083,26 @@ def create_multi_basin_configs(
 
         # Create build.yml with inheritance in base folder (inherit from large_scale build.yml)
         build_config_path = base_dir / "build.yml"
-        with open(build_config_path, "w") as f:
-            f.write("inherits: ../../build.yml\n")
 
+        # Create the build configuration dictionary
+        build_config = {"inherits": "../../build.yml"}
+
+        with open(build_config_path, "w") as f:
+            yaml.dump(build_config, f, default_flow_style=False, sort_keys=False)
         # Create model.yml with inheritance and cluster-specific subbasins in base folder
         model_config_path = base_dir / "model.yml"
+
+        # Convert all cluster values to regular Python integers
+        cluster_ints = [int(subbasin_id) for subbasin_id in cluster]
+
+        # Create the configuration dictionary
+        model_config = {
+            "inherits": "../../model.yml",
+            "general": {"region": {"subbasin": cluster_ints}},
+        }
+
         with open(model_config_path, "w") as f:
-            f.write("inherits: ../../model.yml\n\n")
-            f.write("general:\n")
-            f.write("  region:\n")
-            # Convert all cluster values to regular Python integers
-            cluster_ints = [int(subbasin_id) for subbasin_id in cluster]
-            f.write(f"    subbasin: {cluster_ints}\n")
+            yaml.dump(model_config, f, default_flow_style=False, sort_keys=False)
 
         print(
             f"  Created configuration files in {base_dir.relative_to(working_directory)}"

--- a/geb/cli.py
+++ b/geb/cli.py
@@ -1681,16 +1681,6 @@ def init_multiple_fn(
     help="If set, overwrite existing cluster directories and files.",
 )
 @click.option(
-    "--data-catalog",
-    default=DATA_CATALOG_DEFAULT,
-    help="Path to the data catalog file.",
-)
-@click.option(
-    "--data-provider",
-    default=DATA_PROVIDER_DEFAULT,
-    help="Data provider to use.",
-)
-@click.option(
     "--save-geoparquet",
     type=click.Path(),
     help="Save clusters to geoparquet file at this path. If not specified, saves to 'models/clusters.geoparquet'.",


### PR DESCRIPTION
This PR is a draft implementation of init_multiple functionality. This function allows to create a main folder (now called "large_scale"), in which sub-folders are initiated for clusters of sub-basins with an approx. basin size. These sub-folders contain a build.yml and model.yml, which inherit in the main folder. The model.yml contains the list of downstream sub-basin ID's used to build the model. 

# Pull Request Checklist

## Documentation
- [ ] All new or substantially edited functions have documentation in the style of documentation in other functions.
- [ ] Where neccesary, code comments are added focussing on *why* something is done, rather than *what* is done. The *what* should ideally be evident from the variable naming and structure.
- [ ] All added or substantially edited functions have type annotations for arguments and return types.

## Clarity
- [ ] All variable names are clear and understandable by a non-domain expert.
- [ ] Units should be included and preferably as SI units.
- [ ] All monetary units are nominal USD (face value) for the respective years.

## Testing
- [ ] Tests that are not available on GitHub actions pass (primarly test_model.py).
- [ ] When there is an error, the code fails (early). I.e., the code doesn't silently fail.

*Thank you for helping maintain the code quality!*