### PR TITLE
Fix grammar in runoff concentration documentation

### DIFF
--- a/docs/hydrology/runoff_concentration.md
+++ b/docs/hydrology/runoff_concentration.md
@@ -1,6 +1,6 @@
 # Runoff concentration
 
-The runoff concentration module slows down discharge over several timesteps (i.e. hours). We do this because the runoff has to travel through the gridcell and cannot leave the same timestep as it was generated. We use a triangular weighting method to redistribute the discharge over 6 timesteps (i.e. hours), with the peak discharge being at 3 timesteps (i.e. hours). Only runoff is changed using this approach, the interflow and baseflow remain unchanged. This approach is based on the original CWatM model. The figure below shows an example of how the input runoff is redistributed using the runoff concentration process.
+The runoff concentration module slows down discharge over several timesteps (i.e. hours). We do this because the runoff has to travel through the grid cell and cannot leave in the same timestep in which it was generated. We use a triangular weighting method to redistribute the discharge over 6 timesteps (i.e. hours), with the peak discharge being at 3 timesteps (i.e. hours). Only runoff is changed using this approach, the interflow and baseflow remain unchanged. This approach is based on the original CWatM model. The figure below shows an example of how the input runoff is redistributed using the runoff concentration process.
 
 <img width="1920" height="1440" alt="runoff_concentration" src="https://github.com/user-attachments/assets/486ef5d7-c9e6-4ddb-8905-5f750ed366a4" />
 


### PR DESCRIPTION
Corrected minor grammatical issues for clarity in the runoff concentration module description.

# Pull Request Checklist

## Documentation
- [ ] All new or substantially edited functions have documentation in the style of documentation in other functions.
- [ ] Where neccesary, code comments are added focussing on *why* something is done, rather than *what* is done. The *what* should ideally be evident from the variable naming and structure.
- [ ] All added or substantially edited functions have type annotations for arguments and return types.

## Clarity
- [ ] All variable names are clear and understandable by a non-domain expert.
- [ ] Units should be included and preferably as SI units.
- [ ] All monetary units are nominal USD (face value) for the respective years.

## Testing
- [ ] Tests that are not available on GitHub actions pass (primarly test_model.py).
- [ ] When there is an error, the code fails (early). I.e., the code doesn't silently fail.

*Thank you for helping maintain the code quality!*