### PR TITLE
Simplify and speedup reading of forcing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Improve alignment of data that goes into land surface model, reducing memory contention. And various other optimizations in land surface model.
 - Fix "Inflation not set when model runs to final year of data that was created in build process" ([#808](https://github.com/GEB-model/GEB/issues/808)).
 - Flood events could not and still cannot be simulated during the spinup. However, this was not clear and a funny error about missing files was raised. Now this situation is detected and a clear error is raised ([#806](https://github.com/GEB-model/GEB/issues/806)).
+- Simplify and speedup reading of forcing data. Before we used chunks of only 24 hours and used complex async reading to make it fast. Now that we use much larger chunks and efficient masking, the asynchronous reading made things overly complex and error prone. Simplifying the reading (e.g., dropping the async reader) while optimizing the indexing makes the model 10-20% faster in the test region. Difference is large regions is negligble.
 
 # v1.0.0b23
 - Add documentation, repository, and issue tracker links to `pyproject.toml` ([#797](https://github.com/GEB-model/GEB/issues/797)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Improve alignment of data that goes into land surface model, reducing memory contention. And various other optimizations in land surface model.
 - Fix "Inflation not set when model runs to final year of data that was created in build process" ([#808](https://github.com/GEB-model/GEB/issues/808)).
 - Flood events could not and still cannot be simulated during the spinup. However, this was not clear and a funny error about missing files was raised. Now this situation is detected and a clear error is raised ([#806](https://github.com/GEB-model/GEB/issues/806)).
-- Simplify and speedup reading of forcing data. Before we used chunks of only 24 hours and used complex async reading to make it fast. Now that we use much larger chunks and efficient masking, the asynchronous reading made things overly complex and error prone. Simplifying the reading (e.g., dropping the async reader) while optimizing the indexing makes the model 10-20% faster in the test region. Difference is large regions is negligble.
+- Simplify and speed up reading of forcing data. Before we used chunks of only 24 hours and used complex async reading to make it fast. Now that we use much larger chunks and efficient masking, the asynchronous reading made things overly complex and error prone. Simplifying the reading (e.g., dropping the async reader) while optimizing the indexing makes the model 10-20% faster in the test region. The difference is negligible in large regions.
 
 # v1.0.0b23
 - Add documentation, repository, and issue tracker links to `pyproject.toml` ([#797](https://github.com/GEB-model/GEB/issues/797)).

--- a/geb/forcing.py
+++ b/geb/forcing.py
@@ -19,7 +19,7 @@ from geb.geb_types import (
 from geb.workflows.io import read_grid, read_table
 
 from .module import Module
-from .workflows.io import AsyncGriddedForcingReader
+from .workflows.io import ForcingReader
 
 if TYPE_CHECKING:
     from geb.model import GEBModel
@@ -254,8 +254,8 @@ class ForcingLoader(ABC):
         self.n: int = n
         self.variable: str = variable
         self.grid_mask = grid_mask
-        self.reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-            model.files["other"][f"climate/{variable}"], variable, asynchronous=True
+        self.reader: ForcingReader = ForcingReader(
+            model.files["other"][f"climate/{variable}"], variable
         )
         self.forcing_mask = self._load_forcing_mask()
 

--- a/geb/model.py
+++ b/geb/model.py
@@ -889,10 +889,12 @@ class GEBModel(Module):
         ):
             Hydrology.finalize(self.hydrology)
 
-            # Close all async forcing readers
+            # Close all forcing readers
             if hasattr(self, "forcing"):
                 for forcing_loader in self.forcing.forcing_loaders.values():
-                    if hasattr(forcing_loader, "reader"):
+                    if hasattr(forcing_loader, "reader") and hasattr(
+                        forcing_loader.reader, "close"
+                    ):
                         forcing_loader.reader.close()
 
     def __enter__(self) -> GEBModel:

--- a/geb/reporter.py
+++ b/geb/reporter.py
@@ -724,6 +724,9 @@ def prepare_agent_group(
         )
 
 
+RE_SQUARE_BRACKETS = re.compile(r"\[.*?\]")
+
+
 class Reporter:
     """This class is used to report data to disk."""
 
@@ -946,10 +949,10 @@ class Reporter:
             KeyError: If the variable is not found in the local variables or module attributes.
             AttributeError: If the attribute is not found in the module.
         """
-        current_time = self.model.current_time
-        current_timestep = self.model.current_timestep
-        # here we return None if the value is not to be reported on this timestep
         if "frequency" in config:
+            current_time = self.model.current_time
+            current_timestep = self.model.current_timestep
+            # here we return None if the value is not to be reported on this timestep
             if config["frequency"] == "initial":
                 if current_timestep != 0:
                     return None
@@ -977,10 +980,10 @@ class Reporter:
                 raise ValueError(f"Frequency {config['frequency']} not recognized.")
 
         varname = config["varname"]
-        fancy_index = re.search(r"\[.*?\]", varname)
+        fancy_index: re.Match[str] | None = RE_SQUARE_BRACKETS.search(varname)
         if fancy_index:
-            fancy_index = fancy_index.group(0)
-            varname = varname.replace(fancy_index, "")
+            fancy_index: str = fancy_index.group(0)
+            varname: str = varname.replace(fancy_index, "")
 
         # get the variable
         if varname.startswith("."):
@@ -1002,12 +1005,7 @@ class Reporter:
         if fancy_index:
             value = eval(f"value{fancy_index}")
 
-        # if the value is not None, we check whether the value is valid
-        if isinstance(value, list):
-            value = np.array([v.item() for v in value])
-            for v in value:
-                assert not np.isnan(value) and not np.isinf(v)
-        elif np.isscalar(value):
+        if np.isscalar(value):
             assert not np.isnan(value) and not np.isinf(value)
             if isinstance(value, (np.floating, np.integer, np.bool_)):
                 value = value.item()

--- a/geb/workflows/io.py
+++ b/geb/workflows/io.py
@@ -1,6 +1,5 @@
 """I/O related functions and classes for the GEB project."""
 
-import asyncio
 import bz2
 import datetime
 import hashlib
@@ -10,7 +9,6 @@ import platform
 import shutil
 import subprocess
 import tempfile
-import threading
 import time
 import warnings
 from collections.abc import Hashable
@@ -39,7 +37,6 @@ import zarr.storage
 from pyproj import CRS
 from rasterio.transform import Affine
 from tqdm import tqdm
-from zarr.codecs import BloscCodec
 from zarr.codecs.numcodecs import Delta, _NumcodecsBytesBytesCodec
 from zarr.codecs.zstd import ZstdCodec
 from zarr.core.buffer import NDArrayLike
@@ -1094,11 +1091,10 @@ def get_window(
     return {"x": xslice, "y": yslice}
 
 
-class AsyncGriddedForcingReader:
-    """Thread-safe asynchronous Zarr forcing reader with preload caching.
+class ForcingReader:
+    """Thread-safe Zarr forcing reader with chunk-aligned caching.
 
-    This reader uses the Zarr async API for efficient reads, with a workaround
-    for occasional Zarr async loading issues.
+    Simplified reader that uses standard synchronous Zarr calls.
     """
 
     array: zarr.Array
@@ -1107,21 +1103,15 @@ class AsyncGriddedForcingReader:
         self,
         filepath: Path,
         variable_name: str,
-        asynchronous: bool = True,
     ) -> None:
-        """Initialize the async gridded forcing reader.
+        """Initialize the gridded forcing reader.
 
         Args:
             filepath: Path to the Zarr file containing the forcing data.
             variable_name: Name of the variable to read from the Zarr file.
-            asynchronous: Whether to use asynchronous reading. Default is True.
-
-        Raises:
-            ValueError: If the variable does not use NaN as fill value.
         """
         self.filepath = filepath
         self.variable_name = variable_name
-        self.asynchronous = asynchronous
 
         # Synchronous store and dataset (metadata and coordinates only)
         self.store = zarr.storage.LocalStore(filepath, read_only=True)
@@ -1148,367 +1138,132 @@ class AsyncGriddedForcingReader:
         self.datetime_index: ArrayDatetime64 = pd.to_datetime(
             time, unit=pandas_time_unit, origin=origin
         ).to_numpy()
+        self.global_index: int = -1
+        self.current_chunk_index: int = -1
         self.time_size = self.datetime_index.size
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=ZarrUserWarning)
-            # Check if the variable uses NaN as fill value for the retry workaround
+            # Check if the variable exists
             array = self.ds[self.variable_name]
 
         assert isinstance(array, zarr.Array)
         self.array: zarr.Array = array
-
-        for compressor in self.array.compressors:
-            # Blosc is not supported due to known issues with async reading
-            if isinstance(compressor, BloscCodec):
-                raise ValueError(
-                    f"Variable {self.variable_name} uses Blosc compression, which is not supported by AsyncGriddedForcingReader. Please recompress the data using a different codec (e.g., Zstd)."
-                )
-
-        fill_value = self.array.fill_value
-        # The fill value is NaN if it's a float type and is NaN, or explicitly None for some types
-        has_nan_fill = isinstance(fill_value, (float, np.floating)) and np.isnan(
-            fill_value
-        )
-
-        if not has_nan_fill:
-            raise ValueError(
-                f"Variable {self.variable_name} does not use NaN as fill value, AsyncGriddedForcingReader requires NaN fill value for retry workaround."
-            )
 
         # The on-disk chunk size along the time dimension - we always load full chunks
         # from disk (e.g. 7 * 24 = 168 for weekly hourly data).
         self.time_chunk_size: int = int(self.array.chunks[1])
 
         # Chunk-aligned cache: holds the start index and data for the currently loaded chunk.
-        self.current_chunk_start_index: int = -1
         self.current_chunk_data: TwoDArrayFloat32 | None = None
-        # The time-index at which a background preload has been (or is being) fetched.
-        self.preloaded_chunk_start_index: int = -1
-        self.preloaded_data_future: asyncio.Task | None = None
 
-        # Async event loop setup
-        if self.asynchronous:
-            self.loop: asyncio.AbstractEventLoop | None = asyncio.new_event_loop()
-            self.thread = threading.Thread(target=self.loop.run_forever, daemon=True)
-            self.thread.start()
+    def close(self) -> None:
+        """Close the reader and its resources."""
+        self.store.close()
 
-            # Initialize lock in the shared loop
-            async def _init_lock() -> tuple[asyncio.Lock, asyncio.Lock]:
-                return asyncio.Lock(), asyncio.Lock()
+    def load(self, chunk_index: int) -> TwoDArrayFloat32:
+        """Load a specific chunk from disk.
 
-            self.async_lock, self.io_lock = asyncio.run_coroutine_threadsafe(
-                _init_lock(), self.loop
-            ).result()
-        else:
-            self.loop = None
-            self.async_lock = None
-            self.io_lock = None
-
-    def load(self, start_index: int, end_index: int) -> TwoDArrayFloat32:
-        """Safe synchronous load (only used if asynchronous=False).
+        Args:
+            chunk_index: The time chunk index.
 
         Returns:
             The requested data slice.
         """
         assert isinstance(self.array, zarr.Array)
-        data = self.array[:, start_index:end_index]
+        start_index = chunk_index * self.time_chunk_size
+        end_index = start_index + self.time_chunk_size
+        data = self.array[
+            :,
+            start_index:end_index,
+        ]
+        assert isinstance(data, np.ndarray)
         assert (
             isinstance(data, np.ndarray) and data.dtype == np.float32 and data.ndim == 2
         )
         return data  # ty:ignore[invalid-return-type]
 
-    async def load_await(self, start_index: int, end_index: int) -> TwoDArrayFloat32:
-        """Load data asynchronously via reusable async group.
-
-        Returns:
-            The requested data slice (not a copy - caller must copy if needed).
-
-        Raises:
-            IOError: If the async load returns only NaN values after multiple attempts.
-        """
-        assert self.io_lock is not None
-        async with self.io_lock:
-            # Select the variable array from the pre-opened async group.
-            arr: zarr.AsyncArray[Any] = self.array.async_array
-
-            attempts: int = 100
-
-            # Try up to 100 times
-            for _ in range(attempts):
-                data = await arr.getitem((slice(None), slice(start_index, end_index)))
-
-                if not np.any(np.isnan(data)):
-                    assert (
-                        isinstance(data, np.ndarray)
-                        and data.dtype == np.float32
-                        and data.ndim == 2
-                    )
-                    return data  # ty:ignore[invalid-return-type]
-                print(
-                    f"Async load returned NaN values for indices {start_index}:{end_index}, retrying..."
-                )
-
-            else:
-                raise IOError(
-                    f"Async load failed after {attempts} attempts for indices {start_index}:{end_index}"
-                )
-
-    async def preload_chunk(self, chunk_start: int) -> TwoDArrayFloat32 | None:
-        """Preload the chunk starting at chunk_start asynchronously.
-
-        Args:
-            chunk_start: The time index at which the chunk to preload begins.
-
-        Returns:
-            The preloaded chunk data, or None if beyond available data.
-        """
-        if chunk_start >= self.time_size:
-            return None
-        chunk_end: int = min(chunk_start + self.time_chunk_size, self.time_size)
-        return await self.load_await(chunk_start, chunk_end)
-
-    async def read_timestep_async(
-        self, start_index: int, end_index: int
-    ) -> tuple[TwoDArrayFloat32, np.datetime64]:
-        """Core async read with chunk-aligned caching and background preloading.
-
-        Loads the full on-disk chunk that contains the requested timesteps,
-        caches it, and schedules the next chunk for background preloading so
-        that subsequent requests within the same or the next chunk are cheap.
-
-        Args:
-            start_index: The starting index of the time slice to read.
-            end_index: The exclusive ending index of the time slice to read.
-
-        Returns:
-            A tuple of (requested data slice as a NumPy array, start datetime of the slice).
-
-        Raises:
-            ValueError: If the requested index is out of bounds or spans more
-                than one on-disk chunk.
-            IOError: If the async read returns incomplete data.
-        """
-        if start_index < 0 or end_index > self.time_size:
-            raise ValueError(f"Index out of bounds ({start_index}:{end_index})")
-
-        n: int = end_index - start_index
-        start_date: np.datetime64 = self.datetime_index[start_index]
-
-        # Determine which on-disk chunk this request falls in.
-        chunk_start: int = (start_index // self.time_chunk_size) * self.time_chunk_size
-        chunk_end: int = min(chunk_start + self.time_chunk_size, self.time_size)
-        offset: int = start_index - chunk_start
-
-        # Requests must be aligned with chunk boundaries and never cross it.
-        # This simplifies the reader and ensures that the source data is saved
-        # efficiently for the intended access pattern.
-        if n > self.time_chunk_size:
-            raise ValueError(
-                f"Requested {n} timesteps exceeds on-disk chunk size {self.time_chunk_size}."
-            )
-        if (start_index % n != 0) or (offset + n > (chunk_end - chunk_start)):
-            raise ValueError(
-                f"Requested slice {start_index}:{end_index} is not aligned with "
-                f"the chunk size {self.time_chunk_size} or spacing {n}."
-            )
-
-        assert self.async_lock is not None
-        async with self.async_lock:
-            chunk_data: TwoDArrayFloat32 | None = None
-
-            # Cache hit: the required chunk is already in memory.
-            if (
-                self.current_chunk_data is not None
-                and self.current_chunk_start_index == chunk_start
-            ):
-                chunk_data = self.current_chunk_data
-
-            # Preload hit: the required chunk was being preloaded in the background.
-            elif (
-                self.preloaded_data_future is not None
-                and self.preloaded_chunk_start_index == chunk_start
-            ):
-                try:
-                    chunk_data = await self.preloaded_data_future
-                except Exception:
-                    chunk_data = None
-
-            # Cache miss: cancel any pending (wrong) preload and load from disk.
-            if chunk_data is None:
-                if self.preloaded_data_future and not self.preloaded_data_future.done():
-                    self.preloaded_data_future.cancel()
-                    try:
-                        await self.preloaded_data_future
-                    except asyncio.CancelledError:
-                        pass
-                chunk_data = await self.load_await(chunk_start, chunk_end)
-
-            expected_chunk_len: int = chunk_end - chunk_start
-            if chunk_data.shape[1] != expected_chunk_len:
-                raise IOError(
-                    "Async read returned incomplete data; possible disk contention"
-                )
-
-            # Update the chunk cache.
-            self.current_chunk_start_index = chunk_start
-            self.current_chunk_data = chunk_data
-
-            # Schedule preload of the next chunk unless it is already in flight.
-            next_chunk_start: int = chunk_start + self.time_chunk_size
-            assert self.loop is not None
-            if self.preloaded_chunk_start_index != next_chunk_start:
-                if self.preloaded_data_future and not self.preloaded_data_future.done():
-                    self.preloaded_data_future.cancel()
-                    try:
-                        await self.preloaded_data_future
-                    except asyncio.CancelledError:
-                        pass
-                self.preloaded_chunk_start_index = next_chunk_start
-                self.preloaded_data_future = self.loop.create_task(
-                    self.preload_chunk(next_chunk_start)
-                )
-
-            # Slice out only the requested timesteps from the cached chunk.
-            return chunk_data[:, offset : offset + n], start_date
-
-    def get_index(self, date: datetime.datetime) -> int:
+    def get_index(self, date: datetime.datetime, n: int = 1) -> int:
         """Get the time index for a given datetime.
-
-        Uses binary search for correctness and falls back to an O(1) check
-        against the current chunk boundaries for the common sequential-access case.
 
         Args:
             date: The datetime to find the index for.
+            n: The number of consecutive timesteps to read starting from the returned index. Used for an optimized sequential access check.
 
         Returns:
-            The integer index for the given date.
+            The index of the given datetime in the time dimension.
 
         Raises:
             ValueError: If the date is not found in the time index.
         """
         numpy_date = np.datetime64(date, "ns")
 
-        # Very fast (lol): check whether the date falls within the currently loaded chunk.
-        if self.current_chunk_start_index >= 0:
-            chunk_end: int = min(
-                self.current_chunk_start_index + self.time_chunk_size, self.time_size
-            )
-            chunk_slice = self.datetime_index[
-                self.current_chunk_start_index : chunk_end
-            ]
-            local_idx: npt.NDArray[np.intp] = np.where(chunk_slice == numpy_date)[0]
-            if local_idx.size > 0:
-                return int(self.current_chunk_start_index + local_idx[0])
+        # Sequential access check
+        if self.global_index >= 0 and self.global_index < self.time_size:
+            if self.datetime_index[self.global_index] == numpy_date:
+                return self.global_index
 
-        # Still fast: check whether the date falls within the next chunk.
-        # This the most logical for climate data. That the model requests the next
-        # chunk.
-        next_chunk_start: int = self.current_chunk_start_index + self.time_chunk_size
-        if self.current_chunk_start_index >= 0 and next_chunk_start < self.time_size:
-            next_chunk_end: int = min(
-                next_chunk_start + self.time_chunk_size, self.time_size
-            )
-            next_chunk_slice = self.datetime_index[next_chunk_start:next_chunk_end]
-            local_idx_next: npt.NDArray[np.intp] = np.where(
-                next_chunk_slice == numpy_date
-            )[0]
-            if local_idx_next.size > 0:
-                return int(next_chunk_start + local_idx_next[0])
+            next_idx = self.global_index + n
+            if (
+                next_idx < self.time_size
+                and self.datetime_index[next_idx] == numpy_date
+            ):
+                self.global_index = next_idx
+                return self.global_index
 
-        # Full search via binary search (handles non-sequential access)
-        # This should happen on the very first access and when the model were
-        # to jump around in time, which it typically shouldn't do.
-        idx: int = int(np.searchsorted(self.datetime_index, numpy_date))
-        if idx >= self.time_size or self.datetime_index[idx] != numpy_date:
+        index: int = int(np.searchsorted(self.datetime_index, numpy_date))
+        if index >= self.time_size or self.datetime_index[index] != numpy_date:
             raise ValueError(f"Date {date} not found in {self.filepath}")
-        return idx
+
+        self.global_index = index
+        return index
 
     def read_timestep(
         self, date: datetime.datetime, n: int = 1
     ) -> tuple[npt.NDArray[Any], np.datetime64]:
-        """Return n timesteps starting at date, loading from the on-disk chunk as needed.
-
-        On the first call (or whenever the required chunk is not cached) the full
-        on-disk chunk is fetched from disk and the next chunk is queued for
-        background pre-loading. Subsequent calls for timesteps within the same
-        chunk are served entirely from memory.
+        """Return n timesteps starting at date.
 
         Args:
-            date: Start datetime of the slice to return.
-            n: Number of consecutive timesteps to return. Must not exceed the
-               on-disk chunk size along the time dimension.
+            date: The datetime to read from.
+            n: The number of consecutive timesteps to read starting from date.
 
         Returns:
-            A tuple of (Array of shape (n, y, x) with dtype float32, start datetime of the slice as np.datetime64).
+            A tuple of (data, timestamp) where data is a 2D array of shape (lat, lon) and timestamp is the datetime64 of the first timestep.
 
         Raises:
-            ValueError: If the requested range exceeds available data or the
-                on-disk chunk size.
+            ValueError: If the requested range straddles chunk boundaries or exceeds available range.
+
         """
-        start_index: int = self.get_index(date)
+        start_index: int = self.get_index(date, n)
         end_index: int = start_index + n
         if end_index > self.time_size:
             raise ValueError(
                 f"Requested {n} timesteps from {date} exceeds available range"
             )
 
-        start_date: np.datetime64 = self.datetime_index[start_index]
+        required_chunk_index: int = start_index // self.time_chunk_size
 
-        if self.asynchronous:
-            coro = self.read_timestep_async(start_index, end_index)
-            assert isinstance(self.loop, asyncio.AbstractEventLoop)
-            future = asyncio.run_coroutine_threadsafe(coro, self.loop)
-            return future.result()
-        else:
-            # Synchronous path: respect chunk alignment for consistency.
-            chunk_start: int = (
-                start_index // self.time_chunk_size
-            ) * self.time_chunk_size
-            chunk_end: int = min(chunk_start + self.time_chunk_size, self.time_size)
-            offset: int = start_index - chunk_start
+        # Ensure we do not straddle chunk boundaries
+        if (start_index // self.time_chunk_size) != (
+            (end_index - 1) // self.time_chunk_size
+        ):
+            raise ValueError(
+                f"Requested range [{start_index}, {end_index}) straddles chunk boundaries. All reads must be contained within a single on-disk chunk (size {self.time_chunk_size})."
+            )
 
-            # Requests must be aligned with chunk boundaries and never cross it.
-            if n > self.time_chunk_size:
-                raise ValueError(
-                    f"Requested {n} timesteps exceeds on-disk chunk size {self.time_chunk_size}."
-                )
-            if (start_index % n != 0) or (offset + n > (chunk_end - chunk_start)):
-                raise ValueError(
-                    f"Requested slice {start_index}:{end_index} is not aligned with "
-                    f"the chunk size {self.time_chunk_size} or spacing {n}."
-                )
+        if required_chunk_index != self.current_chunk_index:
+            self.current_chunk_data = self.load(required_chunk_index)
+            self.current_chunk_index = required_chunk_index
 
-            if (
-                self.current_chunk_data is None
-                or self.current_chunk_start_index != chunk_start
-            ):
-                self.current_chunk_data = self.load(chunk_start, chunk_end)
-                self.current_chunk_start_index = chunk_start
+        required_within_chunk_index: int = start_index % self.time_chunk_size
 
-            return self.current_chunk_data[:, offset : offset + n], start_date
+        assert self.current_chunk_data is not None
 
-    def close(self) -> None:
-        """Clean up this instance's async resources."""
-        if not self.asynchronous:
-            return
+        data = self.current_chunk_data[
+            :, required_within_chunk_index : required_within_chunk_index + n
+        ]
 
-        async def cleanup() -> None:
-            """Cancel this instance's pending tasks and close async group."""
-            if self.preloaded_data_future and not self.preloaded_data_future.done():
-                self.preloaded_data_future.cancel()
-            # Stop the loop
-            asyncio.get_event_loop().stop()
-
-        if self.loop and self.loop.is_running():
-            try:
-                # Because we are not writing, we can just cancel the pending preload
-                # task and stop the loop without waiting for it to finish.
-                # This allows for a much faster shutdown, especially if the loop is currently waiting on a slow disk read.
-                asyncio.run_coroutine_threadsafe(cleanup(), self.loop)
-            except Exception:
-                pass
-            # Don't join the thread - it's a daemon and will die when the process dies
+        return data, self.datetime_index[start_index]
 
 
 class WorkingDirectory:

--- a/geb/workflows/io.py
+++ b/geb/workflows/io.py
@@ -1092,10 +1092,7 @@ def get_window(
 
 
 class ForcingReader:
-    """Thread-safe Zarr forcing reader with chunk-aligned caching.
-
-    Simplified reader that uses standard synchronous Zarr calls.
-    """
+    """Zarr forcing reader with chunk-aligned caching."""
 
     array: zarr.Array
 
@@ -1228,7 +1225,7 @@ class ForcingReader:
             n: The number of consecutive timesteps to read starting from date.
 
         Returns:
-            A tuple of (data, timestamp) where data is a 2D array of shape (lat, lon) and timestamp is the datetime64 of the first timestep.
+            A tuple of (data, timestamp) where data is a 1D array of makes size and timestamp is the datetime64 of the first timestep.
 
         Raises:
             ValueError: If the requested range straddles chunk boundaries or exceeds available range.

--- a/tests/workflows/test_io.py
+++ b/tests/workflows/test_io.py
@@ -4,7 +4,7 @@ import shutil
 import warnings
 from datetime import datetime
 from pathlib import Path
-from time import sleep, time
+from time import time
 
 import dask.array
 import numpy as np
@@ -18,7 +18,7 @@ from zarr.codecs.numcodecs import FixedScaleOffset
 
 import geb.workflows.io as io_module
 from geb.workflows.io import (
-    AsyncGriddedForcingReader,
+    ForcingReader,
     calculate_scaling,
     create_hash_from_parameters,
     get_window,
@@ -556,112 +556,14 @@ def zarr_file(varname: str) -> Path:
     return file_path
 
 
-def test_read_timestep_async() -> None:
-    """Test the AsyncGriddedForcingReader class with asynchronous reading.
+def test_read_timestep() -> None:
+    """Test the ForcingReader class.
 
-    This test creates three temporary zarr files with a single variable each.
-    It then creates three AsyncGriddedForcingReader instances to read the data from these
-    files. The test reads several timesteps from the first reader, with varying wait times
-    in between to simulate processing time. It also reads timesteps from the other two readers
-    to ensure that they work correctly. Finally, it cleans up the temporary files.
-
-    Reading a previous timestep should be slow, as it needs to be loaded from disk.
-    Reading the same timestep should be quick, as it is already in the cache.
-    Reading the next timestep after a long wait should be quick, as it is already in the cache.
-    Reading the next timestep after a short wait should be semi-quick, as it is already being
-    loaded in the cache but not yet ready.
-
-    """
-    temperature_file: Path = zarr_file("temperature")
-    precipitation_file: Path = zarr_file("precipitation")
-    pressure_file: Path = zarr_file("pressure")
-    reader1: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        temperature_file, variable_name="temperature", asynchronous=True
-    )
-    reader2: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        precipitation_file, variable_name="precipitation", asynchronous=True
-    )
-    reader3: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        pressure_file, variable_name="pressure", asynchronous=True
-    )
-
-    data0, _ = reader1.read_timestep(datetime(2000, 1, 1))
-
-    sleep(3)  # Simulate some processing time
-
-    t0 = time()
-    data1, _ = reader1.read_timestep(datetime(2000, 1, 2))
-    t1 = time()
-    print("Async - Load next timestep (quick): {:.3f}s".format(t1 - t0))
-
-    # wait half the time it took to load the previous timestep to simulate a short
-    # processing time
-    sleep((t1 - t0) / 2)
-
-    t0 = time()
-    data2, _ = reader1.read_timestep(datetime(2000, 1, 3))
-    t1 = time()
-    print(
-        "Async - Load next timestep short waiting (semi-quick): {:.3f}s".format(t1 - t0)
-    )
-
-    assert (data0 == 0).all()
-    assert (data1 == 1).all()
-    assert (data2 == 2).all()
-    assert data0.dtype == np.float32
-
-    sleep(3)
-
-    t0 = time()
-    data3, _ = reader1.read_timestep(datetime(2000, 1, 4))
-    t1 = time()
-    print("Async - Load next timestep with waiting (quick): {:.3f}s".format(t1 - t0))
-
-    t0 = time()
-    data3, _ = reader1.read_timestep(datetime(2000, 1, 4))
-    t1 = time()
-    print("Async - Load same timestep (quick): {:.3f}s".format(t1 - t0))
-    assert (data3 == 3).all()
-
-    t0 = time()
-    data0, _ = reader1.read_timestep(datetime(2000, 1, 6))
-    t1 = time()
-    print("Async - Load next next timestep (slow): {:.3f}s".format(t1 - t0))
-    assert (data0 == 5).all()
-
-    _, _ = reader1.read_timestep(datetime(2000, 1, 1))
-    _, _ = reader2.read_timestep(datetime(2000, 1, 1))
-    _, _ = reader3.read_timestep(datetime(2000, 1, 1))
-
-    sleep(3)  # Simulate some processing time
-    print("-----------------")
-
-    t0 = time()
-    data1, _ = reader1.read_timestep(datetime(2000, 1, 2))
-    _, _ = reader2.read_timestep(datetime(2000, 1, 2))
-    _, _ = reader3.read_timestep(datetime(2000, 1, 2))
-    t1 = time()
-    print("Async - Load data from three readers (quick): {:.3f}s".format(t1 - t0))
-
-    reader1.close()
-    reader2.close()
-    reader3.close()
-
-    shutil.rmtree(temperature_file)
-    shutil.rmtree(precipitation_file)
-    shutil.rmtree(pressure_file)
-
-
-def test_read_timestep_sync() -> None:
-    """Test the AsyncGriddedForcingReader class with synchronous reading.
-
-    This test verifies that the reader works correctly when asynchronous mode is disabled.
+    This test verifies that the reader works correctly by reading several timesteps.
     It should correctly read data without any preloading mechanism.
     """
     temperature_file: Path = zarr_file("temperature")
-    reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        temperature_file, variable_name="temperature", asynchronous=False
-    )
+    reader: ForcingReader = ForcingReader(temperature_file, variable_name="temperature")
 
     # Test reading single timesteps
     data0, _ = reader.read_timestep(datetime(2000, 1, 1))
@@ -683,7 +585,6 @@ def test_read_timestep_sync() -> None:
     data10, _ = reader.read_timestep(datetime(2000, 1, 11))
     assert (data10 == 10).all()
 
-    reader.close()
     shutil.rmtree(temperature_file)
 
 
@@ -691,63 +592,37 @@ def test_read_multiple_timesteps() -> None:
     """Test reading multiple timesteps at once (n=1).
 
     This test verifies that the reader correctly handles reading consecutive
-    timesteps in single-step calls, and that the data is correct for both async and sync modes.
+    timesteps in single-step calls.
     """
     temperature_file: Path = zarr_file("temperature")
 
-    # Test with asynchronous reading
-    reader_async: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        temperature_file, variable_name="temperature", asynchronous=True
-    )
+    reader: ForcingReader = ForcingReader(temperature_file, variable_name="temperature")
 
     # Read 1 timestep starting from Jan 1
-    data_multi, _ = reader_async.read_timestep(datetime(2000, 1, 1), n=1)
+    data_multi, _ = reader.read_timestep(datetime(2000, 1, 1), n=1)
     assert data_multi.shape == (1000000, 1)
     assert (data_multi == 0).all()
 
-    sleep(2)  # Allow preloading to happen
-
     # Read next 1 timestep
-    t0 = time()
-    data_multi_next, _ = reader_async.read_timestep(datetime(2000, 1, 2), n=1)
-    t1 = time()
-    print(f"Async - Load next timestep (should be quick): {t1 - t0:.3f}s")
+    data_multi_next, _ = reader.read_timestep(datetime(2000, 1, 2), n=1)
     assert data_multi_next.shape == (1000000, 1)
     assert (data_multi_next == 1).all()
 
-    reader_async.close()
-
-    # Test with synchronous reading
-    reader_sync: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        temperature_file, variable_name="temperature", asynchronous=False
-    )
-
-    # Read 1 timestep starting from Jan 1
-    data_multi_sync, _ = reader_sync.read_timestep(datetime(2000, 1, 1), n=1)
-    assert data_multi_sync.shape == (1000000, 1)
-    assert (data_multi_sync == 0).all()
-
-    # Verify that async and sync give same results
-    assert np.array_equal(data_multi, data_multi_sync), "Async and sync results differ"
-
-    reader_sync.close()
     shutil.rmtree(temperature_file)
 
 
-def test_asyncreader_rapid_access() -> None:
-    """Test rapid access of timesteps using AsyncGriddedForcingReader.
+def test_reader_rapid_access() -> None:
+    """Test rapid access of timesteps using ForcingReader.
 
     This test verifies that the reader can handle rapid sequential access of timesteps
     so no sleeps in between reads.
     """
     temperature_file: Path = zarr_file("temperature")
-    reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        temperature_file, variable_name="temperature", asynchronous=True
-    )
+    reader: ForcingReader = ForcingReader(temperature_file, variable_name="temperature")
     for day in range(1, 11):
         data, _ = reader.read_timestep(datetime(2000, 1, day))
         assert (data == day - 1).all()
-    reader.close()
+    shutil.rmtree(temperature_file)
 
 
 HOURLY_CHUNK_SIZE: int = 7 * 24  # one week of hourly data per on-disk chunk
@@ -814,9 +689,10 @@ def test_chunk_aligned_reading_correctness() -> None:
     hourly_file: Path = zarr_file_hourly(varname)
     hours_per_day: int = 24
 
-    for asynchronous in (True, False):
-        reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-            hourly_file, variable_name=varname, asynchronous=asynchronous
+    if True:
+        reader: ForcingReader = ForcingReader(
+            hourly_file,
+            variable_name=varname,
         )
         assert reader.time_chunk_size == HOURLY_CHUNK_SIZE
 
@@ -863,61 +739,44 @@ def test_chunk_aligned_reading_correctness() -> None:
     shutil.rmtree(hourly_file)
 
 
-def test_chunk_aligned_reading_preload_performance() -> None:
-    """Test that chunk-boundary crossings are fast due to background preloading.
+def test_chunk_aligned_reading_performance() -> None:
+    """Test that chunk-aligned reading performs as expected.
 
-    After reading day 7 (last day of chunk 0) with a sufficient sleep to let the
-    background preload of chunk 1 finish, reading day 8 (first day of chunk 1)
-    should be served from the preloaded cache and therefore be substantially faster
-    than a cold disk read.
+    Successive reads within the same chunk should be served from cache.
     """
     varname: str = "temperature_perf"
     hourly_file: Path = zarr_file_hourly(varname)
     hours_per_day: int = 24
 
-    reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        hourly_file, variable_name=varname, asynchronous=True
-    )
+    reader: ForcingReader = ForcingReader(hourly_file, variable_name=varname)
 
-    # Read day 7 to populate the cache for chunk 0 and trigger preload of chunk 1.
-    _, _ = reader.read_timestep(datetime(2000, 1, 7), n=hours_per_day)
+    # Initial read to populate cache for chunk 0
+    _, _ = reader.read_timestep(datetime(2000, 1, 1), n=hours_per_day)
 
-    # Sleep long enough for the background preload to finish.
-    sleep(3)
-
-    # Day 8 crosses into chunk 1 - should be fast because it was preloaded.
+    # Read another day in the same chunk - should be fast (cache hit)
     t0: float = time()
-    data_day8, _ = reader.read_timestep(datetime(2000, 1, 8), n=hours_per_day)
+    data_day2, _ = reader.read_timestep(datetime(2000, 1, 2), n=hours_per_day)
     t1: float = time()
-    print(f"Chunk-boundary read (preloaded): {t1 - t0:.4f}s")
+    print(f"Same-chunk cache hit: {t1 - t0:.4f}s")
 
-    # Verify data correctness.
-    offset_day8: int = HOURLY_CHUNK_SIZE
+    # Verify data correctness for day 2
+    offset_day2: int = 24
     for h in range(hours_per_day):
-        assert (data_day8[:, h] == float(offset_day8 + h)).all()
-
-    # Read same day again (cache hit) - must be essentially instant.
-    t0 = time()
-    data_day8_cached, _ = reader.read_timestep(datetime(2000, 1, 8), n=hours_per_day)
-    t1 = time()
-    print(f"Same-day cache hit: {t1 - t0:.4f}s")
-    assert np.array_equal(data_day8, data_day8_cached)
+        assert (data_day2[:, h] == float(offset_day2 + h)).all()
 
     reader.close()
     shutil.rmtree(hourly_file)
 
 
-def test_async_gridded_forcing_reader_get_index_fast_paths() -> None:
+def test_gridded_forcing_reader_get_index_fast_paths() -> None:
     """Test the fast paths in get_index for current and next chunks."""
     varname: str = "test_get_index"
     hourly_file: Path = zarr_file_hourly(varname)
 
-    reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        hourly_file, variable_name=varname, asynchronous=False
-    )
+    reader: ForcingReader = ForcingReader(hourly_file, variable_name=varname)
 
     # Initial state: current_chunk_start_index is -1
-    assert reader.current_chunk_start_index == -1
+    assert reader.current_chunk_index == -1
 
     # Search for a date in the middle of the first chunk (chunk 0: 0-167)
     date_chunk0 = datetime(2000, 1, 4)  # day 4, hour 0 -> index 72
@@ -927,7 +786,7 @@ def test_async_gridded_forcing_reader_get_index_fast_paths() -> None:
     # Now read a timestep to set current_chunk_start_index
     _, _ = reader.read_timestep(datetime(2000, 1, 1), n=1)
     # HOURLY_CHUNK_SIZE is 168 (7 days)
-    assert reader.current_chunk_start_index == 0
+    assert reader.current_chunk_index == 0
 
     # Fast path 1: same chunk
     idx0_fast = reader.get_index(date_chunk0)
@@ -943,7 +802,7 @@ def test_async_gridded_forcing_reader_get_index_fast_paths() -> None:
     _, _ = reader.read_timestep(
         datetime(2000, 1, 8), n=1
     )  # Sets current_chunk to chunk 1 (index 168)
-    assert reader.current_chunk_start_index == 168
+    assert reader.current_chunk_index == 168 // reader.time_chunk_size
 
     # Fast path 1 (now chunk 1)
     idx1_fast = reader.get_index(date_chunk1)
@@ -975,13 +834,11 @@ def test_async_gridded_forcing_reader_full_chunk_consumption() -> None:
     hourly_file: Path = zarr_file_hourly(varname)
 
     # Test asynchronous mode
-    reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        hourly_file, variable_name=varname, asynchronous=True
-    )
+    reader: ForcingReader = ForcingReader(hourly_file, variable_name=varname)
 
     # Initially no chunk is cached or preloaded
-    assert reader.current_chunk_start_index == -1
-    assert reader.preloaded_chunk_start_index == -1
+    assert reader.current_chunk_index == -1
+    pass
 
     # 1. Consume the first full chunk (7 days = 168 hours)
     # This falls into the fallback path in read_timestep_async (n == chunk_size, offset == 0)
@@ -989,9 +846,9 @@ def test_async_gridded_forcing_reader_full_chunk_consumption() -> None:
     _, _ = reader.read_timestep(datetime(2000, 1, 1), n=HOURLY_CHUNK_SIZE)
 
     # Check that current_chunk_start_index is set to 0
-    assert reader.current_chunk_start_index == 0
+    assert reader.current_chunk_index == 0
     # Check that it triggered preload of the next chunk (index 168)
-    assert reader.preloaded_chunk_start_index == 168
+    pass  # 168
 
     # 2. Wait a bit and check if we have a preload hit for the next chunk
     from time import sleep
@@ -1004,22 +861,20 @@ def test_async_gridded_forcing_reader_full_chunk_consumption() -> None:
     # and that the next preload is triggered)
     _, _ = reader.read_timestep(datetime(2000, 1, 8), n=1)
 
-    assert reader.current_chunk_start_index == 168
-    assert reader.preloaded_chunk_start_index == 168 + HOURLY_CHUNK_SIZE
+    assert reader.current_chunk_index == 168 // reader.time_chunk_size
+    pass  # 168 + HOURLY_CHUNK_SIZE
 
     reader.close()
 
     # Test synchronous mode
-    reader_sync: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        hourly_file, variable_name=varname, asynchronous=False
-    )
+    reader_sync: ForcingReader = ForcingReader(hourly_file, variable_name=varname)
 
     # Initially no chunk is cached
-    assert reader_sync.current_chunk_start_index == -1
+    assert reader_sync.current_chunk_index == -1
 
     # Consume full chunk
     _, _ = reader_sync.read_timestep(datetime(2000, 1, 1), n=HOURLY_CHUNK_SIZE)
-    assert reader_sync.current_chunk_start_index == 0
+    assert reader_sync.current_chunk_index == 0
 
     reader_sync.close()
     shutil.rmtree(hourly_file)
@@ -1035,9 +890,7 @@ def test_chunk_aligned_reading_within_same_day() -> None:
     hourly_file: Path = zarr_file_hourly(varname)
     hours_per_day: int = 24
 
-    reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-        hourly_file, variable_name=varname, asynchronous=True
-    )
+    reader: ForcingReader = ForcingReader(hourly_file, variable_name=varname)
 
     # First read: cold load of chunk 0.
     data_a, _ = reader.read_timestep(datetime(2000, 1, 3), n=hours_per_day)
@@ -1067,16 +920,17 @@ def test_chunk_boundary_spanning_request() -> None:
     hourly_file: Path = zarr_file_hourly(varname)
     hours_per_day: int = 24
 
-    for asynchronous in (True, False):
-        reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-            hourly_file, variable_name=varname, asynchronous=asynchronous
+    if True:
+        reader: ForcingReader = ForcingReader(
+            hourly_file,
+            variable_name=varname,
         )
         assert reader.time_chunk_size == HOURLY_CHUNK_SIZE
 
         # Start at hour 156 (= HOURLY_CHUNK_SIZE - 12): asking for 24 h straddles
         # the boundary between chunk 0 (0-167) and chunk 1 (168-335).
         straddle_start: datetime = datetime(2000, 1, 7, 12)  # hour 156
-        with pytest.raises(ValueError, match="not aligned with the chunk size"):
+        with pytest.raises(ValueError, match="straddles chunk boundaries"):
             reader.read_timestep(straddle_start, n=hours_per_day)
 
         reader.close()
@@ -1099,9 +953,10 @@ def test_first_request_mid_chunk() -> None:
     mid_chunk_start: datetime = datetime(2000, 1, 9, 0)  # hour 192
     start_value: int = 192
 
-    for asynchronous in (True, False):
-        reader: AsyncGriddedForcingReader = AsyncGriddedForcingReader(
-            hourly_file, variable_name=varname, asynchronous=asynchronous
+    if True:
+        reader: ForcingReader = ForcingReader(
+            hourly_file,
+            variable_name=varname,
         )
 
         # Cold cache, first request lands in the middle of chunk 1.

--- a/tests/workflows/test_io.py
+++ b/tests/workflows/test_io.py
@@ -689,52 +689,47 @@ def test_chunk_aligned_reading_correctness() -> None:
     hourly_file: Path = zarr_file_hourly(varname)
     hours_per_day: int = 24
 
-    if True:
-        reader: ForcingReader = ForcingReader(
-            hourly_file,
-            variable_name=varname,
+    reader: ForcingReader = ForcingReader(
+        hourly_file,
+        variable_name=varname,
+    )
+    assert reader.time_chunk_size == HOURLY_CHUNK_SIZE
+
+    # Day 1: hours 0-23, first slice of chunk 0
+    data_day1, _ = reader.read_timestep(datetime(2000, 1, 1), n=hours_per_day)
+    assert data_day1.shape == (16, hours_per_day)
+    for h in range(hours_per_day):
+        assert (data_day1[:, h] == float(h)).all(), f"day1 hour {h} wrong"
+
+    # Day 2: hours 24-47, still within chunk 0 (served from cache)
+    data_day2, _ = reader.read_timestep(datetime(2000, 1, 2), n=hours_per_day)
+    for h in range(hours_per_day):
+        assert (data_day2[:, h] == float(hours_per_day + h)).all(), (
+            f"day2 hour {h} wrong"
         )
-        assert reader.time_chunk_size == HOURLY_CHUNK_SIZE
 
-        # Day 1: hours 0-23, first slice of chunk 0
-        data_day1, _ = reader.read_timestep(datetime(2000, 1, 1), n=hours_per_day)
-        assert data_day1.shape == (16, hours_per_day)
-        for h in range(hours_per_day):
-            assert (data_day1[:, h] == float(h)).all(), f"day1 hour {h} wrong"
+    # Day 7: hours 144-167, last day of chunk 0 (still from cache)
+    data_day7, _ = reader.read_timestep(datetime(2000, 1, 7), n=hours_per_day)
+    offset_day7: int = 6 * hours_per_day
+    for h in range(hours_per_day):
+        assert (data_day7[:, h] == float(offset_day7 + h)).all(), f"day7 hour {h} wrong"
 
-        # Day 2: hours 24-47, still within chunk 0 (served from cache)
-        data_day2, _ = reader.read_timestep(datetime(2000, 1, 2), n=hours_per_day)
-        for h in range(hours_per_day):
-            assert (data_day2[:, h] == float(hours_per_day + h)).all(), (
-                f"day2 hour {h} wrong"
-            )
+    # Day 8: hours 168-191, first day of chunk 1
+    data_day8, _ = reader.read_timestep(datetime(2000, 1, 8), n=hours_per_day)
+    offset_day8: int = HOURLY_CHUNK_SIZE  # start of chunk 1
+    for h in range(hours_per_day):
+        assert (data_day8[:, h] == float(offset_day8 + h)).all(), f"day8 hour {h} wrong"
 
-        # Day 7: hours 144-167, last day of chunk 0 (still from cache)
-        data_day7, _ = reader.read_timestep(datetime(2000, 1, 7), n=hours_per_day)
-        offset_day7: int = 6 * hours_per_day
-        for h in range(hours_per_day):
-            assert (data_day7[:, h] == float(offset_day7 + h)).all(), (
-                f"day7 hour {h} wrong"
-            )
+    # Non-sequential jump to week 3, day 1 (chunk 2)
+    week3_start: datetime = datetime(2000, 1, 15)  # 14 days * 24h = index 336
+    data_week3, _ = reader.read_timestep(week3_start, n=hours_per_day)
+    offset_week3: int = 2 * HOURLY_CHUNK_SIZE
+    for h in range(hours_per_day):
+        assert (data_week3[:, h] == float(offset_week3 + h)).all(), (
+            f"week3 hour {h} wrong"
+        )
 
-        # Day 8: hours 168-191, first day of chunk 1
-        data_day8, _ = reader.read_timestep(datetime(2000, 1, 8), n=hours_per_day)
-        offset_day8: int = HOURLY_CHUNK_SIZE  # start of chunk 1
-        for h in range(hours_per_day):
-            assert (data_day8[:, h] == float(offset_day8 + h)).all(), (
-                f"day8 hour {h} wrong"
-            )
-
-        # Non-sequential jump to week 3, day 1 (chunk 2)
-        week3_start: datetime = datetime(2000, 1, 15)  # 14 days * 24h = index 336
-        data_week3, _ = reader.read_timestep(week3_start, n=hours_per_day)
-        offset_week3: int = 2 * HOURLY_CHUNK_SIZE
-        for h in range(hours_per_day):
-            assert (data_week3[:, h] == float(offset_week3 + h)).all(), (
-                f"week3 hour {h} wrong"
-            )
-
-        reader.close()
+    reader.close()
 
     shutil.rmtree(hourly_file)
 
@@ -828,58 +823,6 @@ def test_gridded_forcing_reader_get_index_fast_paths() -> None:
     shutil.rmtree(hourly_file)
 
 
-def test_async_gridded_forcing_reader_full_chunk_consumption() -> None:
-    """Test that consuming a full chunk in one go correctly updates cache and preload state."""
-    varname: str = "test_full_chunk"
-    hourly_file: Path = zarr_file_hourly(varname)
-
-    # Test asynchronous mode
-    reader: ForcingReader = ForcingReader(hourly_file, variable_name=varname)
-
-    # Initially no chunk is cached or preloaded
-    assert reader.current_chunk_index == -1
-    pass
-
-    # 1. Consume the first full chunk (7 days = 168 hours)
-    # This falls into the fallback path in read_timestep_async (n == chunk_size, offset == 0)
-    # but still happens to be chunk-aligned.
-    _, _ = reader.read_timestep(datetime(2000, 1, 1), n=HOURLY_CHUNK_SIZE)
-
-    # Check that current_chunk_start_index is set to 0
-    assert reader.current_chunk_index == 0
-    # Check that it triggered preload of the next chunk (index 168)
-    pass  # 168
-
-    # 2. Wait a bit and check if we have a preload hit for the next chunk
-    from time import sleep
-
-    sleep(1.0)
-
-    # Accessing the first timestep of the next chunk should now hit the preload
-    # We can check this by verifying that the preload_hit logic path is taken
-    # (Since we can't easily check prints, we check that it doesn't crash
-    # and that the next preload is triggered)
-    _, _ = reader.read_timestep(datetime(2000, 1, 8), n=1)
-
-    assert reader.current_chunk_index == 168 // reader.time_chunk_size
-    pass  # 168 + HOURLY_CHUNK_SIZE
-
-    reader.close()
-
-    # Test synchronous mode
-    reader_sync: ForcingReader = ForcingReader(hourly_file, variable_name=varname)
-
-    # Initially no chunk is cached
-    assert reader_sync.current_chunk_index == -1
-
-    # Consume full chunk
-    _, _ = reader_sync.read_timestep(datetime(2000, 1, 1), n=HOURLY_CHUNK_SIZE)
-    assert reader_sync.current_chunk_index == 0
-
-    reader_sync.close()
-    shutil.rmtree(hourly_file)
-
-
 def test_chunk_aligned_reading_within_same_day() -> None:
     """Test that multiple reads within the same day (same chunk) are served from cache.
 
@@ -920,20 +863,19 @@ def test_chunk_boundary_spanning_request() -> None:
     hourly_file: Path = zarr_file_hourly(varname)
     hours_per_day: int = 24
 
-    if True:
-        reader: ForcingReader = ForcingReader(
-            hourly_file,
-            variable_name=varname,
-        )
-        assert reader.time_chunk_size == HOURLY_CHUNK_SIZE
+    reader: ForcingReader = ForcingReader(
+        hourly_file,
+        variable_name=varname,
+    )
+    assert reader.time_chunk_size == HOURLY_CHUNK_SIZE
 
-        # Start at hour 156 (= HOURLY_CHUNK_SIZE - 12): asking for 24 h straddles
-        # the boundary between chunk 0 (0-167) and chunk 1 (168-335).
-        straddle_start: datetime = datetime(2000, 1, 7, 12)  # hour 156
-        with pytest.raises(ValueError, match="straddles chunk boundaries"):
-            reader.read_timestep(straddle_start, n=hours_per_day)
+    # Start at hour 156 (= HOURLY_CHUNK_SIZE - 12): asking for 24 h straddles
+    # the boundary between chunk 0 (0-167) and chunk 1 (168-335).
+    straddle_start: datetime = datetime(2000, 1, 7, 12)  # hour 156
+    with pytest.raises(ValueError, match="straddles chunk boundaries"):
+        reader.read_timestep(straddle_start, n=hours_per_day)
 
-        reader.close()
+    reader.close()
 
     shutil.rmtree(hourly_file)
 
@@ -953,31 +895,26 @@ def test_first_request_mid_chunk() -> None:
     mid_chunk_start: datetime = datetime(2000, 1, 9, 0)  # hour 192
     start_value: int = 192
 
-    if True:
-        reader: ForcingReader = ForcingReader(
-            hourly_file,
-            variable_name=varname,
-        )
+    reader: ForcingReader = ForcingReader(
+        hourly_file,
+        variable_name=varname,
+    )
 
-        # Cold cache, first request lands in the middle of chunk 1.
-        data, _ = reader.read_timestep(mid_chunk_start, n=hours_per_day)
-        assert data.shape == (16, hours_per_day)
-        for h in range(hours_per_day):
-            assert (data[:, h] == float(start_value + h)).all(), (
-                f"async={asynchronous} hour {h}: expected {start_value + h}"
-            )
+    # Cold cache, first request lands in the middle of chunk 1.
+    data, _ = reader.read_timestep(mid_chunk_start, n=hours_per_day)
+    assert data.shape == (16, hours_per_day)
+    for h in range(hours_per_day):
+        assert (data[:, h] == float(start_value + h)).all()
 
-        # Verify the chunk is now cached by reading another day inside the same chunk.
-        # hour 216 = chunk 1 offset 48. 216 % 24 == 0.
-        next_day_start: datetime = datetime(2000, 1, 10, 0)  # hour 216
-        data_next, _ = reader.read_timestep(next_day_start, n=hours_per_day)
-        assert data_next.shape == (16, hours_per_day)
-        for h in range(hours_per_day):
-            assert (data_next[:, h] == float(216 + h)).all(), (
-                f"async={asynchronous} intra-chunk hour {h}: expected {216 + h}"
-            )
+    # Verify the chunk is now cached by reading another day inside the same chunk.
+    # hour 216 = chunk 1 offset 48. 216 % 24 == 0.
+    next_day_start: datetime = datetime(2000, 1, 10, 0)  # hour 216
+    data_next, _ = reader.read_timestep(next_day_start, n=hours_per_day)
+    assert data_next.shape == (16, hours_per_day)
+    for h in range(hours_per_day):
+        assert (data_next[:, h] == float(216 + h)).all()
 
-        reader.close()
+    reader.close()
 
     shutil.rmtree(hourly_file)
 


### PR DESCRIPTION
Simplify and speedup reading of forcing data. Before we used chunks of only 24 hours and used complex async reading to make it fast. Now that we use much larger chunks and efficient masking, the asynchronous reading made things overly complex and error prone. Simplifying the reading (e.g., dropping the async reader) while optimizing the indexing makes the model 10-20% faster in the test region. Difference is large regions is negligble

# Pull Request Checklist

## Documentation
- [ ] All new or substantially edited functions have documentation in the style of documentation in other functions.
- [ ] Where neccesary, code comments are added focussing on *why* something is done, rather than *what* is done. The *what* should ideally be evident from the variable naming and structure.
- [ ] All added or substantially edited functions have type annotations for arguments and return types.

## Clarity
- [ ] All variable names are clear and understandable by a non-domain expert.
- [ ] Units should be included and preferably as SI units.
- [ ] All monetary units are nominal USD (face value) for the respective years.

## Testing
- [ ] Tests that are not available on GitHub actions pass (primarly test_model.py).
- [ ] When there is an error, the code fails (early). I.e., the code doesn't silently fail.

*Thank you for helping maintain the code quality!*