### PR TITLE
reset loading back to table instead of gpkg

### DIFF
--- a/geb/agents/households.py
+++ b/geb/agents/households.py
@@ -166,7 +166,11 @@ class Households(AgentBaseClass):
             "COST_CONTENTS_USD_SQM",
             "COMID",
         ]
-        self.buildings = read_geom(self.model.files["geom"]["assets/open_building_map"])
+        # Skip loading the geometry column to save memory
+        self.buildings = read_table(
+            self.model.files["geom"]["assets/open_building_map"],
+            columns=columns_to_load,
+        )
 
         self.buildings["object_type"] = (
             "building_unprotected"  # before it was "building_structure"


### PR DESCRIPTION
I noticed that the buildings were again loaded as gpkg (this is quite expensive in RAM for large areas, so I reset it back to loading the buildings as table (and only loading geometries when required). @rafaellaglo @roy-pontman I saw this change in your branch, so I added you as reviewers to check if this results in issues for your applications!

# Pull Request Checklist

## Documentation
- [ ] All new or substantially edited functions have documentation in the style of documentation in other functions.
- [ ] Where neccesary, code comments are added focussing on *why* something is done, rather than *what* is done. The *what* should ideally be evident from the variable naming and structure.
- [ ] All added or substantially edited functions have type annotations for arguments and return types.

## Clarity
- [ ] All variable names are clear and understandable by a non-domain expert.
- [ ] Units should be included and preferably as SI units.
- [ ] All monetary units are nominal USD (face value) for the respective years.

## Testing
- [ ] Tests that are not available on GitHub actions pass (primarly test_model.py).
- [ ] When there is an error, the code fails (early). I.e., the code doesn't silently fail.

*Thank you for helping maintain the code quality!*